### PR TITLE
[MAN-34] formula: remove autobump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-26.04, macos-13]
     runs-on: ${{ matrix.os }}
-    container:
-      image: ghcr.io/homebrew/brew:main
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,10 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-13]
+        os: [ubuntu-26.04, macos-13]
     runs-on: ${{ matrix.os }}
+    container:
+      image: ghcr.io/homebrew/brew:main
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-24.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Formula/g/gflags.rb
+++ b/Formula/g/gflags.rb
@@ -5,8 +5,6 @@ class Gflags < Formula
   sha256 "34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf"
   license "BSD-3-Clause"
 
-  no_autobump! because: "Managed by Adagio"
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "39734f92f5ba9261156f77cff1ccb83f372b426d6062a380216f4f52f4d491ab"

--- a/Formula/r/rocksdb.rb
+++ b/Formula/r/rocksdb.rb
@@ -23,7 +23,7 @@ class Rocksdb < Formula
   depends_on "zstd"
 
   uses_from_macos "bzip2"
-  
+
   on_linux do
     depends_on "zlib-ng-compat"
   end

--- a/Formula/r/rocksdb.rb
+++ b/Formula/r/rocksdb.rb
@@ -77,9 +77,9 @@ class Rocksdb < Formula
                                 *extra_args,
                                 "-lz", "-lbz2",
                                 "-L#{lib}", "-lrocksdb",
-                                "-L#{Formula["snappy"].opt_lib}", "-lsnappy",
-                                "-L#{Formula["lz4"].opt_lib}", "-llz4",
-                                "-L#{Formula["zstd"].opt_lib}", "-lzstd"
+                                "-L#{formula_opt_lib("snappy")}", "-lsnappy",
+                                "-L#{formula_opt_lib("lz4")}", "-llz4",
+                                "-L#{formula_opt_lib("zstd")}", "-lzstd"
     system "./db_test"
 
     assert_match "sst_dump --file=", shell_output("#{bin}/rocksdb_sst_dump --help 2>&1")

--- a/Formula/r/rocksdb.rb
+++ b/Formula/r/rocksdb.rb
@@ -23,7 +23,10 @@ class Rocksdb < Formula
   depends_on "zstd"
 
   uses_from_macos "bzip2"
-  uses_from_macos "zlib"
+  
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     args = %W[

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -6,8 +6,6 @@ class Snappy < Formula
   license "BSD-3-Clause"
   head "https://github.com/google/snappy.git", branch: "master"
 
-  no_autobump! because: "Managed by Adagio"
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "326d8c9a73e0990a43fefe96d2e29355fcd6f42906710017bd1a3baf4401bb33"
     sha256 cellar: :any,                 arm64_sonoma:  "28b0702ed678a35c6d03cb4d91f975e17b3b5af7480418f3c82f46365e55533d"


### PR DESCRIPTION
Installing onfocusio/libs/gflags fails with:

```
Error: onfocusio/libs/gflags: no_autobump! can only be used in official Homebrew taps.
```

no_autobump! is now restricted to official Homebrew taps, so it should be removed from our formulas.